### PR TITLE
README with setup and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,5 @@
 # NKI MoE Challenge
 
-## Challenge Overview
-
-This repository provides a package containing the PyTorch model of Qwen3-30B-A3B, a state-of-the-art Mixture of Experts (MoE) architecture. This model **can be compiled with AWS Neuron SDK and run on** a **Trainium3 instance.** The main file in this package is `qwen.py` which contains the model implementation in PyTorch.
-
-Participants will develop custom kernels using the Neuron Kernel Interface (NKI) to optimize inference for the Qwen3-30B-A3B model, which features 128 total experts with 8 active experts per token.
-
-## Core Task
-
-Write NKI kernels that improve upon the baseline implementation by optimizing areas among the following:
-
-### MoE-Specific Kernels
-* **Expert routing kernel:** Token-to-expert assignment with efficient gating computation
-* **Sparse expert execution:** Optimized matrix multiplications that exploit 8/128 sparsity
-* **Expert aggregation kernel:** Combining outputs from active experts with learned weights
-* **Dynamic batching kernel:** Grouping tokens by expert assignment for efficient execution
-
-### Memory Management Kernels
-* **Expert weight loading:** Efficient on-chip caching strategies for 128 expert parameters
-* **Activation management:** Optimized tensor layouts for token routing and expert computation
-* **KV-cache optimization:** Memory-efficient attention mechanisms for MoE decoder layers
-
-### Attention and FFN Kernels
-* **Flash attention variants:** Optimized attention for MoE architectures
-* **Fused operations:** Combining multiple operations to reduce memory traffic
-* **Layer normalization:** Efficient normalization kernels for MoE layers
-
-## Technical Environment
-
-### Hardware
-* **Platform:** AWS Trainium3 (trn3.3xlarge instances)
-* **Compute:** 4 Logical NeuronCores per instance
-* **Memory:** 144GB HBM memory capacity
-* **Architecture:** NeuronCore architecture with tensor, vector, and scalar engines
-
-### Model
-* **Architecture:** Qwen3-30B-A3B
-* **Parameters:** 30B total parameters
-* **Experts:** 128 experts with 8 active per token
-* **Type:** Mixture of Experts architecture
-
-### Software
-* **SDK:** AWS Neuron SDK 2.27 (released in December 2025), with extra points to upgrade to the latest SDK
-* **Programming Interface:** Neuron Kernel Interface (NKI) with Python
-  * Direct access to NeuronCore hardware primitives
-  * Support for custom memory layouts and data movement
-* **Framework:** Software support for the specified MoE model with a TP=4 baseline provided
-
-### Baseline
-Reference implementation with standard PyTorch operators compiled through Neuron compiler.
-
-**Key requirement:** All performance-critical operations must be implemented as custom NKI kernels. Participants cannot rely solely on compiler optimizations—they must write low-level NKI code to achieve competitive performance.
 
 ## Getting Started
 
@@ -58,7 +7,7 @@ To learn NKI, follow [the official NKI guide](https://awsdocs-neuron.readthedocs
 
 ## Setup Steps
 
-1. Create a Trainium3 instance with AWS Neuron SDK v2.28 using EC2 based on the [setup guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/setup/neuron-setup/multiframework/multi-framework-ubuntu24-neuron-dlami.html#setup-ubuntu24-multi-framework-dlami).
+1. Create a Trainium2 instance with AWS Neuron SDK v2.28 using EC2 based on the [setup guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/setup/neuron-setup/multiframework/multi-framework-ubuntu24-neuron-dlami.html#setup-ubuntu24-multi-framework-dlami).
 2. Activate the Neuron virtual environment to run inference by running the appropriate activation command for your SDK version. `source /opt/aws_neuronx_venv_pytorch_2_9_nxd_inference/bin/activate`
 3. Clone this repository and run `cd [PATH]/nki-moe` where `[PATH]` is the directory where you have performed the clone.
 4. Download the Qwen3-30B-A3B model to a `~/qwen-30b-a3b/hf_model` folder in your root directory. We recommend doing so using the [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/en/guides/cli). You can install this by running `pip3 install huggingface_hub[cli]`. You will also need to create an [access token](https://huggingface.co/docs/hub/en/security-tokens).
@@ -79,61 +28,6 @@ Key areas to focus on:
 1. **Profiling:** If you would like to profile your implementation in order to get a better understanding of performance bottlenecks and opportunities for optimization, you can use the [Neuron Profiler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-profile-user-guide.html).
 2. **Benchmarking:** You can also leverage the [NKI benchmarking API](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.benchmark.html) to retrieve execution latency statistics.
 
-## Submission
+## Contact
 
-Your submission should be a single Python file called `qwen.py`. This file should contain implementations of NKI kernels and also modifications to the original model to invoke these NKI kernels. This file should work as a plug-in replacement for the original `qwen.py` of the reference PyTorch implementation provided in this repository.
-
-Submission link will be provided closer to the contest date.
-
-## Benchmarks
-
-Submissions will be tested using 25 benchmarks (prompts) with varying context lengths and batch sizes. We have provided prompts in `prompts.txt` with their corresponding metadata (prompt ID, prompt length, recommended sequence length, and baseline latency/throughput) in `prompt_data.txt`. There are 2 methods of testing these prompts:
-
-1. To avoid recompilation per prompt, you can use a global sequence length (we suggest 1024) for all prompts. Run `python main.py --enable-nki --mode evaluate_all --seq-len 1024`.
-2. Alternatively, you can use a unique sequence length for each prompt (suggested sequence lengths are the third entry in each row of `prompt_data.txt`) at the cost of recompiling the model for each prompt. Run `python test.py` to evaluate these prompts in this fashion.
-
-The remaining 20 prompts will be withheld for evaluation. All benchmarks will become publicly available after the contest is complete.
-
-## Evaluation and Scoring
-
-The contest organizers will execute each team's submission across the twenty withheld benchmarks on a dedicated Trainium3 instance. The submissions will be evaluated on:
-
-1) **Accuracy** of generated output vs. our reference implementation. Accuracy evaluation will be a binary assessor: Any benchmark that fails an accuracy threshold will result in a score of 0.
-2) **Latency** (Time to first token (TTFT))
-3) **Throughput** measured as output tokens / second
-4) **Amount of model written in NKI** (measured as NKI FLOPS / total model FLOPS) (will be applied as a scaling factor for (b) and (c)). Note: NKI FLOPs measures the number of multiply-accumulate (MAC) operations.
-
-Rankings will be established by calculating the total normalized number of points per team, where points are normalized against the baseline.
-
-We define **points** as **Accuracy** (binary) **\* Reduced Latency \* Increased Throughput \* (1 + Normalized NKI FLOPS)**, where:
-
-* **Accuracy** = 1 if accuracy matches or exceeds a predetermined threshold, 0 otherwise
-* **Reduced Latency** = Reference implementation TTFT divided by submission TTFT
-* **Increased Throughput** = Submission tokens/sec divided by reference implementation tokens/sec
-* **Normalized NKI FLOPS** = Submission NKI FLOPS divided by total model FLOPS
-
-For example, a submission that is sufficiently accurate, with 10x reduced latency, 2x increased throughput, and 0.85 normalized NKI FLOPS would obtain 1 \* 10 \* 2 \* 1.85 \= 37 points. For reference, the baseline submission would receive a score of 1.
-
-## Presentations
-
-Teams who successfully submit an entry will be invited to present an informal overview of their approach (roughly 10 to 15 minutes) at a special session held during the Workshop & Tutorial days. Winners will be announced later in the week, with full results being released soon after the conference.
-
-## Contest Eligibility
-
-All are welcome to participate in the contest (including teams from academia, industry, and elsewhere) with the exception of the Contest Organizers and employees of the Contest Sponsor. Individuals are prohibited from participating in multiple teams. In order to be eligible for prizes, teams must commit to releasing an open-source version of their implementation prior to the next conference.
-
-## Frequently Asked Questions
-
-To raise a question, please create an issue in this repository, or feel free to reach out to the contest organizers directly.
-
-## Related Work
-
-* TBD
-
-## Contest Organizers
-
-* Emery Berger (Amazon Web Services), [emerydb@amazon.com](mailto:emerydb@amazon.com)
-* Aninda Manocha (Amazon Web Services)
-* Wei Tang (Amazon Web Services)
-* Emily Webber (Amazon Web Services)
-* Ziyang Xu (Amazon Web Services)
+**Email**: [nki-mlsys-2026@amazon.com](mailto:nki-mlsys-2026@amazon.com)


### PR DESCRIPTION
PR for README. 

For now, the code has been tested on `trn2.3xl` with latest Neuron SDK(2.27.0) DLAMI. Here are the results -

```
Compiler status PASS 2026-01-12 20:52:33.000143: 16801 [INFO]: Compilation Successfully Completed for model.MODULE_c47c33a9e54a08013404+835fa4e2.hlo_module.pb Neuron: Finished Compilation for all HLOs in 27.88873863220215 seconds ..Completed run_backend_driver. 

Compiler status PASS Neuron: Done preparing weight layout transformation Neuron: Finished building model in 251.37784934043884 seconds Neuron: SKIPPING pre-sharding the checkpoints. The checkpoints will be sharded during load time. Compiling and tracing time: 251.6660952430002 seconds 

Loading model to Neuron... Neuron: Sharding weights on load... Neuron: Sharding weights for ranks: 0...3 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:630] > initializing tensor model parallel with size 4 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:631] > initializing pipeline model parallel with size 1 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:632] > initializing context model parallel with size 1 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:633] > initializing data parallel with size 1 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:634] > initializing world size to 4 [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:379] [rank_0_pp-1_tp-1_dp-1_cp-1] Chosen Logic for replica groups ret_logic=<PG_Group_Logic.LOGIC1: (<function ascending_ring_PG_group at 0x73927481e0c0>, 'Ascending Ring PG Group')> [2026-01-12 20:53:07.131: I neuronx_distributed/parallel_layers/parallel_state.py:658] [rank_0_pp-1_tp-1_dp-1_cp-1] tp_groups: replica_groups.tp_groups=[[0, 1, 2, 3]] [2026-01-12 20:53:07.132: I neuronx_distributed/parallel_layers/parallel_state.py:659] [rank_0_pp-1_tp-1_dp-1_cp-1] dp_groups: replica_groups.dp_groups=[[0], [1], [2], [3]] [2026-01-12 20:53:07.132: I neuronx_distributed/parallel_layers/parallel_state.py:660] [rank_0_pp-1_tp-1_dp-1_cp-1] pp_groups: replica_groups.pp_groups=[[0], [1], [2], [3]] [2026-01-12 20:53:07.132: I neuronx_distributed/parallel_layers/parallel_state.py:661] [rank_0_pp-1_tp-1_dp-1_cp-1] cp_groups: replica_groups.cp_groups=[[0], [1], [2], [3]] [2026-01-12 20:53:07.132: I neuronx_distributed/parallel_layers/parallel_state.py:662] [rank_0_pp-1_tp-1_dp-1_cp-1] ep_model_groups: replica_groups.ep_model_groups=[[0], [1], [2], [3]] [2026-01-12 20:53:07.132: I neuronx_distributed/parallel_layers/parallel_state.py:663] [rank_0_pp-1_tp-1_dp-1_cp-1] ep_data_groups: replica_groups.ep_data_groups=[[0], [1], [2], [3]] /opt/aws_neuronx_venv_pytorch_2_9_nxd_inference/lib/python3.12/site-packages/neuronx_distributed/trace/trace.py:642: UserWarning: Removing redundant keys from checkpoint: ['layers.26.self_attn.k_proj.weight', 'layers.26.self_attn.o_proj.weight', 'layers.26.self_attn.q_proj.weight', 'layers.26.self_attn.v_proj.weight', 'layers.27.self_attn.k_proj.weight', 'layers.27.self_attn.o_proj.weight', 'layers.27.self_attn.q_proj.weight', 'layers.27.self_attn.v_proj.weight', 'layers.28.self_attn.k_proj.weight', 'layers.28.self_attn.o_proj.weight', 'layers.28.self_attn.q_proj.weight', 'layers.28.self_attn.v_proj.weight', 'layers.19.self_attn.k_proj.weight', 'layers.19.self_attn.o_proj.weight', 'layers.19.self_attn.q_proj.weight', 'layers.19.self_attn.v_proj.weight', 'layers.20.self_attn.k_proj.weight', 'layers.20.self_attn.o_proj.weight', 'layers.20.self_attn.q_proj.weight', 'layers.20.self_attn.v_proj.weight', 'layers.21.self_attn.k_proj.weight', 'layers.21.self_attn.o_proj.weight', 'layers.21.self_attn.q_proj.weight', 'layers.21.self_attn.v_proj.weight', 'layers.38.self_attn.k_proj.weight', 'layers.38.self_attn.o_proj.weight', 'layers.38.self_attn.q_proj.weight', 'layers.38.self_attn.v_proj.weight', 'layers.39.self_attn.k_proj.weight', 'layers.39.self_attn.o_proj.weight', 'layers.39.self_attn.q_proj.weight', 'layers.39.self_attn.v_proj.weight', 'layers.40.self_attn.k_proj.weight', 'layers.40.self_attn.o_proj.weight', 'layers.40.self_attn.q_proj.weight', 'layers.40.self_attn.v_proj.weight', 'layers.41.self_attn.k_proj.weight', 'layers.41.self_attn.o_proj.weight', 'layers.41.self_attn.q_proj.weight', 'layers.41.self_attn.v_proj.weight', 'layers.29.self_attn.k_proj.weight', 'layers.29.self_attn.o_proj.weight', 'layers.29.self_attn.q_proj.weight', 'layers.29.self_attn.v_proj.weight', 'layers.30.self_attn.k_proj.weight', 'layers.30.self_attn.o_proj.weight', 'layers.30.self_attn.q_proj.weight', 'layers.30.self_attn.v_proj.weight', 'layers.31.self_attn.k_proj.weight', 'layers.31.self_attn.o_proj.weight', 'layers.31.self_attn.q_proj.weight', 'layers.31.self_attn.v_proj.weight', 'layers.35.self_attn.k_proj.weight', 'layers.35.self_attn.o_proj.weight', 'layers.35.self_attn.q_proj.weight', 'layers.35.self_attn.v_proj.weight', 'layers.36.self_attn.k_proj.weight', 'layers.36.self_attn.o_proj.weight', 'layers.36.self_attn.q_proj.weight', 'layers.36.self_attn.v_proj.weight', 'layers.37.self_attn.k_proj.weight', 'layers.37.self_attn.o_proj.weight', 'layers.37.self_attn.q_proj.weight', 'layers.37.self_attn.v_proj.weight', 'layers.0.self_attn.k_proj.weight', 'layers.0.self_attn.o_proj.weight', 'layers.0.self_attn.q_proj.weight', 'layers.0.self_attn.v_proj.weight', 'layers.1.self_attn.k_proj.weight', 'layers.1.self_attn.o_proj.weight', 'layers.1.self_attn.q_proj.weight', 'layers.1.self_attn.v_proj.weight', 'layers.2.self_attn.k_proj.weight', 'layers.2.self_attn.o_proj.weight', 'layers.2.self_attn.q_proj.weight', 'layers.2.self_attn.v_proj.weight', 'layers.32.self_attn.k_proj.weight', 'layers.32.self_attn.o_proj.weight', 'layers.32.self_attn.q_proj.weight', 'layers.32.self_attn.v_proj.weight', 'layers.33.self_attn.k_proj.weight', 'layers.33.self_attn.o_proj.weight', 'layers.33.self_attn.q_proj.weight', 'layers.33.self_attn.v_proj.weight', 'layers.34.self_attn.k_proj.weight', 'layers.34.self_attn.o_proj.weight', 'layers.34.self_attn.q_proj.weight', 'layers.34.self_attn.v_proj.weight', 'layers.3.self_attn.k_proj.weight', 'layers.3.self_attn.o_proj.weight', 'layers.3.self_attn.q_proj.weight', 'layers.3.self_attn.v_proj.weight', 'layers.4.self_attn.k_proj.weight', 'layers.4.self_attn.o_proj.weight', 'layers.4.self_attn.q_proj.weight', 'layers.4.self_attn.v_proj.weight', 'layers.5.self_attn.k_proj.weight', 'layers.5.self_attn.o_proj.weight', 'layers.5.self_attn.q_proj.weight', 'layers.5.self_attn.v_proj.weight', 'layers.45.self_attn.k_proj.weight', 'layers.45.self_attn.o_proj.weight', 'layers.45.self_attn.q_proj.weight', 'layers.45.self_attn.v_proj.weight', 'layers.46.self_attn.k_proj.weight', 'layers.46.self_attn.o_proj.weight', 'layers.46.self_attn.q_proj.weight', 'layers.46.self_attn.v_proj.weight', 'layers.47.self_attn.k_proj.weight', 'layers.47.self_attn.o_proj.weight', 'layers.47.self_attn.q_proj.weight', 'layers.47.self_attn.v_proj.weight', 'layers.22.self_attn.k_proj.weight', 'layers.22.self_attn.o_proj.weight', 'layers.22.self_attn.q_proj.weight', 'layers.22.self_attn.v_proj.weight', 'layers.23.self_attn.k_proj.weight', 'layers.23.self_attn.o_proj.weight', 'layers.23.self_attn.q_proj.weight', 'layers.23.self_attn.v_proj.weight', 'layers.24.self_attn.k_proj.weight', 'layers.24.self_attn.o_proj.weight', 'layers.24.self_attn.q_proj.weight', 'layers.24.self_attn.v_proj.weight', 'layers.25.self_attn.k_proj.weight', 'layers.25.self_attn.o_proj.weight', 'layers.25.self_attn.q_proj.weight', 'layers.25.self_attn.v_proj.weight', 'layers.10.self_attn.k_proj.weight', 'layers.10.self_attn.o_proj.weight', 'layers.10.self_attn.q_proj.weight', 'layers.10.self_attn.v_proj.weight', 'layers.11.self_attn.k_proj.weight', 'layers.11.self_attn.o_proj.weight', 'layers.11.self_attn.q_proj.weight', 'layers.11.self_attn.v_proj.weight', 'layers.12.self_attn.k_proj.weight', 'layers.12.self_attn.o_proj.weight', 'layers.12.self_attn.q_proj.weight', 'layers.12.self_attn.v_proj.weight', 'layers.42.self_attn.k_proj.weight', 'layers.42.self_attn.o_proj.weight', 'layers.42.self_attn.q_proj.weight', 'layers.42.self_attn.v_proj.weight', 'layers.43.self_attn.k_proj.weight', 'layers.43.self_attn.o_proj.weight', 'layers.43.self_attn.q_proj.weight', 'layers.43.self_attn.v_proj.weight', 'layers.44.self_attn.k_proj.weight', 'layers.44.self_attn.o_proj.weight', 'layers.44.self_attn.q_proj.weight', 'layers.44.self_attn.v_proj.weight', 'layers.6.self_attn.k_proj.weight', 'layers.6.self_attn.o_proj.weight', 'layers.6.self_attn.q_proj.weight', 'layers.6.self_attn.v_proj.weight', 'layers.7.self_attn.k_proj.weight', 'layers.7.self_attn.o_proj.weight', 'layers.7.self_attn.q_proj.weight', 'layers.7.self_attn.v_proj.weight', 'layers.8.self_attn.k_proj.weight', 'layers.8.self_attn.o_proj.weight', 'layers.8.self_attn.q_proj.weight', 'layers.8.self_attn.v_proj.weight', 'layers.9.self_attn.k_proj.weight', 'layers.9.self_attn.o_proj.weight', 'layers.9.self_attn.q_proj.weight', 'layers.9.self_attn.v_proj.weight', 'layers.13.self_attn.k_proj.weight', 'layers.13.self_attn.o_proj.weight', 'layers.13.self_attn.q_proj.weight', 'layers.13.self_attn.v_proj.weight', 'layers.14.self_attn.k_proj.weight', 'layers.14.self_attn.o_proj.weight', 'layers.14.self_attn.q_proj.weight', 'layers.14.self_attn.v_proj.weight', 'layers.15.self_attn.k_proj.weight', 'layers.15.self_attn.o_proj.weight', 'layers.15.self_attn.q_proj.weight', 'layers.15.self_attn.v_proj.weight', 'layers.16.self_attn.k_proj.weight', 'layers.16.self_attn.o_proj.weight', 'layers.16.self_attn.q_proj.weight', 'layers.16.self_attn.v_proj.weight', 'layers.17.self_attn.k_proj.weight', 'layers.17.self_attn.o_proj.weight', 'layers.17.self_attn.q_proj.weight', 'layers.17.self_attn.v_proj.weight', 'layers.18.self_attn.k_proj.weight', 'layers.18.self_attn.o_proj.weight', 'layers.18.self_attn.q_proj.weight', 'layers.18.self_attn.v_proj.weight'] warnings.warn(f"Removing redundant keys from checkpoint: {keys_to_delete}") Neuron: Done Sharding weights in 48.90824350699995 Neuron: Finished weights loading in 73.20152160000043 seconds Neuron: Warming up the model. 2026-Jan-12 20:54:22.0954 16801:20454 [2] int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t**):219 CCOM WARN NET/OFI Failed to initialize rdma protocol 2026-Jan-12 20:54:22.0955 16801:20454 [2] int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t**):354 CCOM WARN NET/OFI aws-ofi-nccl initialization failed 2026-Jan-12 20:54:22.0957 16801:20454 [2] ncclResult_t nccl_net_ofi_init_no_atexit_fini_v6(ncclDebugLogger_t):183 CCOM WARN NET/OFI Initializing plugin failed 2026-Jan-12 20:54:22.0958 16801:20454 [2] net_plugin.cc:97 CCOM WARN OFI plugin initNet() failed is EFA enabled? Neuron: Warmup completed in 0.8360159397125244 seconds. 

Generating outputs... Prompts: ['I believe the meaning of life is'] Generated outputs: Output 0: I believe the meaning of life is to find your gift. The purpose of life is to give it away. So, what is your gift? What is your unique contribution to the world? What is your special talent, your passion, your calling? What is it that you can do better than anyone else? What is it that you can do that others can't? What is it that you can do that others don't even think of doing? What is it that you can do that others can't do? What is it that you can do that others can't do? What is it that you can do that others can't do 

```