### PR TITLE
Fix find_hlos() reading baseline HLO instead of submission HLO on trn3

### DIFF
--- a/main.py
+++ b/main.py
@@ -951,12 +951,14 @@ def main():
             accuracy = 1
 
         elif args.platform_target == "trn3":
-            model, tokenizer, generation_config = prepare_inference(
-                qwen.NeuronQwen3MoeForCausalLM, args
-            )
-
+            # Compile baseline first; both prepare_inference calls write to
+            # /tmp/nxd_model/, so the second compile is what find_hlos() reads.
             base_model, _, base_generation_config = prepare_inference(
                 baseline_qwen.NeuronQwen3MoeForCausalLM, args
+            )
+
+            model, tokenizer, generation_config = prepare_inference(
+                qwen.NeuronQwen3MoeForCausalLM, args
             )
 
             accuracy = run_accuracy_check(
@@ -1055,12 +1057,14 @@ def main():
         print(f"\nTotal Score: {total_score}\n")
 
     elif args.mode == "evaluate_all" and args.platform_target == "trn3":
-        model, tokenizer, generation_config = prepare_inference(
-            qwen.NeuronQwen3MoeForCausalLM, args
-        )
-
+        # Compile baseline first; both prepare_inference calls write to
+        # /tmp/nxd_model/, so the second compile is what find_hlos() reads.
         base_model, _, base_generation_config = prepare_inference(
             baseline_qwen.NeuronQwen3MoeForCausalLM, args
+        )
+
+        model, tokenizer, generation_config = prepare_inference(
+            qwen.NeuronQwen3MoeForCausalLM, args
         )
 
         prompts = parse_prompts("prompts.txt")


### PR DESCRIPTION
## Problem

In `evaluate_single + trn3` and `evaluate_all + trn3`, `prepare_inference` is called twice and both calls write traced/HLO artefacts to the same `/tmp/nxd_model/` directory. The submission is compiled first and the baseline second, so the baseline's HLO overwrites the submission's.

After both compiles complete, `find_hlos()` reads `/tmp/nxd_model/<model>/_tp0_bk0/`, which contains the baseline HLO, not the submission's. `count_nki_flop_ratio` therefore measures the baseline rather than the submission.

The downstream effect is in `calculate_score`:

```python
score = accuracy * reduced_latency * increased_throughput * (1 + nki_flop_ratio)
```

The `(1 + nki_flop_ratio)` factor reflects the baseline (typically 0 for an unmodified baseline), regardless of how much NKI work the submission actually does. Submissions can verify locally by inspecting `/var/tmp/neuron-compile-cache/MODULE_<submission_hash>/model.hlo_module.pb` (the submission's HLO, with NKI custom-calls) versus `/tmp/nxd_model/<model>/_tp0_bk0/...hlo_module.pb` (the baseline HLO that `find_hlos()` actually returns).

## Fix

Swap the order of the two `prepare_inference` calls in both trn3 paths so the baseline runs first and the submission runs second. The submission's HLO is then the artefact left on disk for `find_hlos()` to read.

Both calls still happen with identical args, so the accuracy check (`base_model` vs `model`) and the per-prompt latency/throughput measurement are unchanged.

## Diff

Two block-swaps, no other changes:

- `main.py:953-960` (`evaluate_single + trn3`)
- `main.py:1057-1064` (`evaluate_all + trn3`)

## Verification

- `python3 -c "import ast; ast.parse(open('main.py').read())"` passes.
- Call signatures unchanged; only call ordering changes.
- `validate` mode is not modified because that path does not call `find_hlos()`.

## Why now

Raising this ahead of the 4/30 deadline because it materially affects scoring: the `(1 + nki_flop_ratio)` multiplier currently caps at 1 for any submission whose subclass differs from the baseline, irrespective of the submission's actual NKI usage. If the intent is for `find_hlos()` to measure the submission, this is a one-line ordering change. If the intent is for `find_hlos()` to measure the baseline, that intent is not currently documented and submissions cannot tell from the harness which is correct. Either way, the current behaviour is ambiguous and worth resolving before scoring.

Related discussion: #30.